### PR TITLE
enabled strict mode and declaration generation

### DIFF
--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -1,0 +1,61 @@
+/**
+ * Represents an SNMP varbind.
+ */
+export interface Varbind {
+    oid: string;
+    type: number;
+    value: any;
+}
+/**
+ * Represents a discovered host with its IP, and the community string, varbinds, and associated rule that was used to discover it.
+ */
+export interface Host {
+    /**
+     * The IP address of the host.
+     */
+    ip: string;
+    /**
+     * The SNMP community string used to discover the host.
+     */
+    community: string;
+    /**
+     * The varbinds returned from the SNMP request to discover the host.
+     */
+    varbinds: Varbind[];
+    /**
+     * An array of references to the rules that the host was discovered with.
+     */
+    rule: Rule;
+}
+/**
+ * Represents a rule used to discover hosts in a subnet.
+ */
+export interface Rule {
+    /**
+     * A user-friendly name for the rule.
+     */
+    name: string;
+    /**
+     * The subnet to scan for hosts, in CIDR notation (e.g., '192.168.1.0/24').
+     */
+    subnet: string;
+    /**
+     * Array of SNMP community strings to try for each host.
+     */
+    communities: string[];
+    /**
+     * Array of OIDs to fetch using SNMP.
+     */
+    oids: string[];
+    /**
+     * Options for the net-snmp session.
+     */
+    options?: object;
+    /**
+     * A function that determines if a host matches the rule based on the IP and varbinds.
+     * @param ip - The IP address of the host.
+     * @param varbinds - The varbinds returned from the SNMP request.
+     * @returns - A boolean indicating if the host matches the rule.
+     */
+    matchFunction(ip: string, varbinds: Varbind[]): boolean;
+}

--- a/dist/snmp-scout.d.ts
+++ b/dist/snmp-scout.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="node" />
+import { Readable } from 'node:stream';
+import { Rule, Host } from './interfaces';
+/**
+ * Discovers hosts on a network using SNMP and a set of rules.
+ * The function returns a Readable stream of discovered hosts.
+ *
+ * @param rules - An array of rules to process for host discovery.
+ * @param concurrency - The maximum number of concurrent SNMP requests allowed.
+ * @returns A Readable stream of discovered hosts.
+ */
+declare function discoverHosts(rules: Rule[], concurrency?: number, streamOutput?: boolean): Readable | Promise<Host[]>;
+export { discoverHosts };

--- a/dist/snmp-scout.js
+++ b/dist/snmp-scout.js
@@ -1,32 +1,9 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.discoverHosts = void 0;
 // snmp-scout.ts
-const stream_1 = require("stream");
-const netSnmp = __importStar(require("net-snmp"));
+const node_stream_1 = require("node:stream");
+const netSnmp = require("net-snmp");
 const utils_1 = require("./utils");
 /**
  * Fetches SNMP varbinds for a specific IP address and community.
@@ -102,7 +79,7 @@ async function processRule(rule, output, queue) {
  * @returns A Readable stream of discovered hosts.
  */
 function discoverHosts(rules, concurrency = 50, streamOutput = false) {
-    const output = new stream_1.Readable({ objectMode: true, read() { } });
+    const output = new node_stream_1.Readable({ objectMode: true, read() { } });
     const queue = new utils_1.AsyncConcurrentTaskQueue(concurrency);
     rules.forEach((rule) => processRule(rule, output, queue));
     queue.onFinished(() => {

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Converts an IP address string to an integer.
+ *
+ * @param ip - The IP address string.
+ * @returns The integer representation of the IP address.
+ */
+export declare function ipToInt(ip: string): number;
+/**
+ * Converts an integer to an IP address string.
+ *
+ * @param integer - The integer representation of the IP address.
+ * @returns The IP address string.
+ */
+export declare function intToIp(integer: number): string;
+/**
+ * AsyncConcurrentTaskQueue manages a queue of tasks with concurrency control.
+ */
+export declare class AsyncConcurrentTaskQueue {
+    private concurrency;
+    private tasks;
+    private active;
+    private errors;
+    private internalPromise;
+    private resolveInternalPromise;
+    private rejectInternalPromise;
+    constructor(concurrency: number);
+    private run;
+    private next;
+    add(task: () => Promise<void>): void;
+    onFinished(callback: (errors: Error[] | null) => void): void;
+}

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -31,6 +31,8 @@ exports.intToIp = intToIp;
  */
 class AsyncConcurrentTaskQueue {
     constructor(concurrency) {
+        this.resolveInternalPromise = () => { };
+        this.rejectInternalPromise = () => { };
         this.concurrency = concurrency;
         this.tasks = [];
         this.active = 0;
@@ -46,7 +48,7 @@ class AsyncConcurrentTaskQueue {
             await task();
         }
         catch (error) {
-            this.errors.push(error);
+            this.errors.push(error instanceof Error ? error : new Error(String(error)));
         }
         this.active--;
         this.next();

--- a/src/net-snmp.d.ts
+++ b/src/net-snmp.d.ts
@@ -1,0 +1,67 @@
+declare module 'net-snmp' {
+    export enum ErrorStatus {
+        NoError = 0,
+        TooBig = 1,
+        NoSuchName = 2,
+        BadValue = 3,
+        ReadOnly = 4,
+        GenErr = 5,
+        NoAccess = 6,
+        WrongType = 7,
+        WrongLength = 8,
+        WrongEncoding = 9,
+        WrongValue = 10,
+        NoCreation = 11,
+        InconsistentValue = 12,
+        ResourceUnavailable = 13,
+        CommitFailed = 14,
+        UndoFailed = 15,
+        AuthorizationError = 16,
+        NotWritable = 17,
+        InconsistentName = 18,
+    }
+
+    export enum ObjectType {
+        Boolean = 2,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        OID = 6,
+        Sequence = 16,
+        IpAddress = 64,
+        Counter = 65,
+        Gauge = 66,
+        TimeTicks = 67,
+        Opaque = 68,
+        Counter64 = 70,
+        NoSuchObject = 128,
+        NoSuchInstance = 129,
+        EndOfMibView = 130,
+    }
+
+    export interface Varbind {
+        oid: string;
+        type: ObjectType;
+        value: any;
+    }
+
+    export interface Session {
+        get: (oids: string[], callback: (error: Error | null, varbinds: Varbind[]) => void) => void;
+        close: () => void;
+    }
+
+    export interface Options {
+        port?: number;
+        retries?: number;
+        timeout?: number;
+        transport?: string;
+        trapPort?: number;
+        version?: string;
+        idBitsSize?: number;
+        context?: string;
+    }
+
+    export function createSession(target: string, community: string, options?: Options): Session;
+    export function isVarbindError(varbind: Varbind): boolean;
+}

--- a/src/snmp-scout.ts
+++ b/src/snmp-scout.ts
@@ -1,5 +1,5 @@
 // snmp-scout.ts
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import * as netSnmp from 'net-snmp';
 import { AsyncConcurrentTaskQueue, ipToInt, intToIp } from './utils';
 import { Rule, Varbind, Host } from './interfaces';
@@ -17,7 +17,7 @@ async function getSNMPVarbinds(
   ip: string,
   oids: string[],
   community: string,
-  options: object
+  options?: object
 ): Promise<Varbind[]> {
   const session = netSnmp.createSession(ip, community, options);
   const varbinds = await new Promise<Varbind[]>((resolve, reject) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,8 +33,8 @@ export class AsyncConcurrentTaskQueue {
     private active: number;
     private errors: Array<Error>;
     private internalPromise: Promise<void>;
-    private resolveInternalPromise: () => void;
-    private rejectInternalPromise: (errors: Array<Error>) => void;
+    private resolveInternalPromise: (value?: void | PromiseLike<void>) => void = () => {};
+    private rejectInternalPromise: (reason?: any) => void = () => {};
 
     constructor(concurrency: number) {
         this.concurrency = concurrency;
@@ -53,7 +53,7 @@ export class AsyncConcurrentTaskQueue {
         try {
             await task();
         } catch (error) {
-            this.errors.push(error);
+            this.errors.push(error instanceof Error ? error: new Error(String(error)));
         }
         this.active--;
         this.next();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
-    "compilerOptions": {
-      "module": "CommonJS",
-      "target": "ES2018",
-      "outDir": "dist",
-      "rootDir": "src",
-      "strict": false,
-      "esModuleInterop": true,
-      "forceConsistentCasingInFileNames": true
-    },
-    "include": ["src/**/*.ts"],
-    "exclude": ["node_modules", "**/*.test.ts"]
-  }
-  
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2018",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
- enabled declaration in tsconfig.json
- removed esModuleInterop
- removed forceConsistentCasingInFileNames
- formatted tsconfig.json
- added rough net-snmp.d.ts for used interfaces, enums, and functions
- switched to node:stream for importing Readable
- tweaked getSNMPVarbinds function declaration to pass strict checking
- tweaked AsyncConcurrentTaskQueue to pass strict checking